### PR TITLE
Fixed "spelling" in mentors.txt

### DIFF
--- a/people/mentors.txt
+++ b/people/mentors.txt
@@ -3,7 +3,7 @@ Expressed in pairs of (contributor) -> (mentor)
 Janek -> Carl
 Phil -> Graham
 Colin -> James Lowe
-Camile (? or Cecile or something with a C?) -> Bertrand
+Cecile -> Bertrand
 
 everybody else -> Janek (whatever he's willing to do)
 


### PR DESCRIPTION
Hi, Graham,

here is a link for reference:
http://lists.gnu.org/archive/html/lilypond-devel/2011-08/msg00739.html
