### PR TITLE
fix for Patchy problems with issue 2240(?)

### DIFF
--- a/patches/compile_lilypond_test.py
+++ b/patches/compile_lilypond_test.py
@@ -139,8 +139,10 @@ class AutoCompile():
 
     def patch(self, filename, reverse=False):
         os.chdir(self.src_build_dir)
-        reverse = "--reverse" if reverse else ""
-        cmd = "git apply %s %s" % (reverse, filename)
+        if reverse:
+            cmd = "git reset --hard"
+        else:
+            cmd = "git apply %s --index" % filename
         returncode = os.system(cmd)
         if returncode != 0:
             self.logfile.failed_step("patch", filename)
@@ -176,6 +178,9 @@ class AutoCompile():
 
     def clean(self, issue_id=None):
         self.runner(self.build_dir, "nice make clean"
+            ,
+            issue_id)
+        self.runner(self.build_dir, "nice git clean -f"
             ,
             issue_id)
 


### PR DESCRIPTION
applies patches with --index so that no untracked files will be left after reverting them; reverts patches using git reset --hard.  Does git clean to be extra sure that no untracked files are present.
