### PR TITLE
Clean up as much as possible between runs

### DIFF
--- a/patches/compile_lilypond_test/__init__.py
+++ b/patches/compile_lilypond_test/__init__.py
@@ -291,6 +291,10 @@ class AutoCompile (object):
     def configure (self, issue_id=None):
         self.runner (self.src_build_dir, "./autogen.sh --noconfigure",
             issue_id, "autogen.sh")
+        if self.build_dir != self.src_build_dir:
+            # clear out the build dir, except for out-test-baseline subdirs.
+            run ("find %s ! -wholename \"*out-test-baseline*\" -type f -exec rm -f {} \\;"
+                 % self.build_dir, wrapped=True)
         self.runner (self.build_dir,
             os.path.join (self.src_build_dir, "configure") + " --disable-optimising",
             issue_id, "configure", env=dict (config.items ("configure_environment")))


### PR DESCRIPTION
Make sure we have a clean build dir before configure/make/make check.

Also, report the result of "git reset --hard" in the log.
