### PR TITLE
Rietveld's "too large to download" patches.

### DIFF
--- a/patches/projecthosting_patches.py
+++ b/patches/projecthosting_patches.py
@@ -80,7 +80,7 @@ class RietveldIssue (CodeReviewIssue):
             # http://code.google.com/p/rietveld/issues/detail?id=196).
             # Try to download individual patches for each file instead,
             # and concatenate them to obtain the complete patch.
-            api_url2 = os.path.join (api_url, patchset)
+            api_url2 = os.path.join (api_url, str (patchset))
             request2 = urllib2.Request (api_url2)
             response2 = urllib2.urlopen (request2).read ()
             riet_patchset_json = json.loads (response2)


### PR DESCRIPTION
Allow to download "too large to download" patchsets.

Avoid the 404 error on patchsets that are "too large". Since patch download links are available for individual files, we download them one by one and concatenate them to obtain the complete patch.

Workaround for Rietveld issue 196:
http://code.google.com/p/rietveld/issues/detail?id=196

Test bed: issue 3502
http://code.google.com/p/lilypond/issues/detail?id=3502
